### PR TITLE
Fix background roundness

### DIFF
--- a/src/layout/background.js
+++ b/src/layout/background.js
@@ -39,7 +39,7 @@ Object.assign( Background.prototype, {
         g.save();
         g.fillStyle = this.color;
         g.beginPath();
-        createRoundedRect(g, 10, this.bounds);
+        createRoundedRect(g, this.rounded, this.bounds);
         g.closePath();
         g.fill();
         g.restore();


### PR DESCRIPTION
The background has a default roundness of 10 which cannot be modified by setter/getter. 

![image](https://user-images.githubusercontent.com/12801153/76644006-769fd300-6556-11ea-9e92-681e01c97aea.png)
